### PR TITLE
fix go module path from linkedin/goavro to tokopedia/goavro

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/linkedin/goavro
+module github.com/tokopedia/goavro
 
 require github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db


### PR DESCRIPTION
change module path in go.mod file from linkedin/goavro to tokopedia/goavro to enable users using go mod when using this tokopedia's version of goavro